### PR TITLE
Clean up dependencies

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,9 +3,6 @@
 
 (package-file "groovy-imports.el")
 
-(depends-on "s")
-(depends-on "pcache")
-
 (development
  (depends-on "cask-package-toolset")
  (depends-on "f")


### PR DESCRIPTION
Because 's' and 'pcache' are read by 'package-file'.
