### PR TITLE
Fix error when the package-and-class regex doesn’t match

### DIFF
--- a/groovy-imports.el
+++ b/groovy-imports.el
@@ -107,8 +107,9 @@
   "Explode the import and return (pkg . class) for the given IMPORT.
 
 Example 'groovy.sql.Sql' returns '(\"groovy.sql\" \"Sql\")."
-  (when import
-    (cl-subseq (s-match "\\\(.*\\\)\\\.\\\([A-Z].+\\\);?" import) 1)))
+  (when-let* (import
+              (package-and-class (s-match "\\\(.*\\\)\\\.\\\([A-Z].+\\\);?" import)))
+    (cl-subseq package-and-class 1)))
 
 (defun groovy-imports-import-for-line ()
   "Return the fully-qualified class name for the import line."

--- a/test/java-imports-test.el
+++ b/test/java-imports-test.el
@@ -131,7 +131,9 @@
           '("java.util" "Map")))
   (should
    (equal (groovy-imports-get-package-and-class "org.foo.bar.baz.ThingOne")
-          '("org.foo.bar.baz" "ThingOne"))))
+          '("org.foo.bar.baz" "ThingOne")))
+  (should
+   (equal (groovy-imports-get-package-and-class "somePackage.*") nil)))
 
 ;; End:
 ;;; groovy-imports-test.el ends here


### PR DESCRIPTION
When an import such as the following is encountered, the regular expression
doesn’t match:

    import somePackage.*

This will cause ‘s-match’ to return nil, which ‘cl-subseq’ doesn’t handle. This
change makes the ‘groovy-imports-get-package-and-class’ return nil when there is
no match instead of raise an error.

Alternatively the regular expression could be changed to support that import
statement, but in that case we add ‘*’ to the import cache. I don’t think that’s
something we want to have happen.